### PR TITLE
fix: proper camelCase properties in TSX file

### DIFF
--- a/src/assets/Chevron.tsx
+++ b/src/assets/Chevron.tsx
@@ -9,8 +9,8 @@ export function Chevron() {
       <path
         d="M0.5 7L3.5 4L0.5 1"
         stroke="#CAC9CB"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   );

--- a/src/assets/Error.tsx
+++ b/src/assets/Error.tsx
@@ -9,23 +9,23 @@ export function Error(props: any) {
       <path
         d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
         stroke="#E86143"
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
         d="M15 9L9 15"
         stroke="#E86143"
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
         d="M9 9L15 15"
         stroke="#E86143"
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   );


### PR DESCRIPTION
Currently getting an issue: 
<img width="386" alt="Screen Shot 2022-07-13 at 1 26 01 PM" src="https://user-images.githubusercontent.com/3442998/178828064-ba7502b3-5763-469a-a26f-ebe8b7f351d0.png">
e

This is because two TSX files, `Chevron.tsx` and `Error.tsx`, have CSS-style cashed-spacing instead of JS-style camelCase. this PR fixes this and gets rid of the error