### PR TITLE
feat: confirm transactions before refreshing the page

### DIFF
--- a/src/components/forums/forum/ForumContent.tsx
+++ b/src/components/forums/forum/ForumContent.tsx
@@ -224,7 +224,8 @@ export function ForumContent(props: ForumContentProps) {
         setDescription("");
         setAccessToken(undefined);
         setShowNewTopicModal(false);
-        update();
+        forumObject.connection.confirmTransaction(tx)
+          .then(() => update());
       } else {
         setCreatingNewTopic(false);
         setModalInfo({

--- a/src/components/forums/topic/CreatePost.tsx
+++ b/src/components/forums/topic/CreatePost.tsx
@@ -58,7 +58,10 @@ export function CreatePost(props: CreatePostProps) {
 
     try {
       const tx = await createForumPost(post, topicId, collectionId);
-      update();
+      if (tx) {
+        Forum.connection.confirmTransaction(tx)
+          .then(() => update());
+      }
       setLoading(false);
       setIsNotificationHidden(false);
       setNotificationContent({

--- a/src/components/forums/topic/PostContent.tsx
+++ b/src/components/forums/topic/PostContent.tsx
@@ -97,7 +97,10 @@ export function PostContent(props: PostContentProps) {
         ),
         type: MessageType.success,
       });
-      update();
+      if (tx) {
+        forum.connection.confirmTransaction(tx)
+          .then(() => update());
+      }
       setTimeout(
         () => setIsNotificationHidden(true),
         NOTIFICATION_BANNER_TIMEOUT
@@ -128,7 +131,10 @@ export function PostContent(props: PostContentProps) {
         type: MessageType.success,
         body: `The post was deleted`,
       });
-      update();
+      if (tx) {
+        forum.connection.confirmTransaction(tx)
+          .then(() => update());
+      }
       setShowDeleteConfirmation(false);
       setDeleting(false);
     } catch (error: any) {

--- a/src/components/forums/topic/TopicContent.tsx
+++ b/src/components/forums/topic/TopicContent.tsx
@@ -120,7 +120,10 @@ export function TopicContent(props: TopicContentProps) {
         ),
         okPath: forumPath,
       });
-      update();
+      if (tx) {
+        forum.connection.confirmTransaction(tx)
+          .then(() => update());
+      }
       setShowDeleteConfirmation(false);
       setDeletingTopic(false);
       return tx;

--- a/src/utils/postbox/postboxWrapper.ts
+++ b/src/utils/postbox/postboxWrapper.ts
@@ -140,7 +140,7 @@ export interface IForum {
 
 export class DispatchForum implements IForum {
   public wallet: WalletInterface;
-  private connection: web3.Connection;
+  public connection: web3.Connection;
   public isNotEmpty: boolean;
   public permission: Permission;
   public cluster: web3.Cluster;

--- a/src/views/ForumView/index.tsx
+++ b/src/views/ForumView/index.tsx
@@ -165,11 +165,13 @@ export const ForumView = (props: ForumViewProps) => {
 
       if (!_.isNil(res?.forum)) {
         if (!_.isNil(tokenAccess)) {
-          await forumObject.setForumPostRestriction(collectionPublicKey!, {
+          const tx = await forumObject.setForumPostRestriction(collectionPublicKey!, {
             nftOwnership: {
               collectionId: tokenAccess,
             },
           });
+          forumObject.connection.confirmTransaction(tx)
+            .then(() => update());
         }
 
         setShowNewForumModal(false);
@@ -187,7 +189,6 @@ export const ForumView = (props: ForumViewProps) => {
           ),
           type: MessageType.success,
         });
-        update();
       }
     } catch (e: any) {
       if (e.error.code === 4001) {


### PR DESCRIPTION
Currently when posting or creating a topic, an update is triggered immediately. On mainnet this means that the update may happen before the transaction is confirmed, so data is not fetched. This PR makes it so that the code waits for the transaction to be confirmed before updating