### PR TITLE
Handle metadata with no uri and http urls that would not otherwise load

### DIFF
--- a/src/components/forums/topic/GiveAward.tsx
+++ b/src/components/forums/topic/GiveAward.tsx
@@ -14,6 +14,7 @@ import {
 
 import { SolanaLogo, Plus } from "../../../assets";
 import { useForum } from "../../../contexts/DispatchProvider";
+import { DisplayableToken } from '../../../utils/postbox/postboxWrapper';
 
 enum AwardType {
   NFT = "NFT",
@@ -45,17 +46,9 @@ export function GiveAward(props: GiveAwardProps) {
   const [selectedType, setSelectedType] = useState<AwardType>(); // TODO (Ana): include both types later
   const [selectedAmount, setSelectedAmount] = useState(0);
   const [loadingNFT, setLoadingNFT] = useState(false);
-  const [selectedNFT, setSelectedNFT] = useState<{
-    mint: string;
-    name: string;
-    uri: string;
-  }>();
+  const [selectedNFT, setSelectedNFT] = useState<DisplayableToken>();
   const [nfts, setNFTs] = useState<
-    {
-      mint: string;
-      name: string;
-      uri: string;
-    }[]
+    DisplayableToken[]
   >([]);
 
   const attachAward = async () => {
@@ -145,7 +138,7 @@ export function GiveAward(props: GiveAwardProps) {
                         nft.mint === selectedNFT?.mint ? "selectedNFT" : ""
                       }`}
                       onClick={() => setSelectedNFT(nft)}>
-                      <img src={nft.uri} />
+                      <img src={nft.uri.toString()} />
                       <div className="giftName">{nft.name}</div>
                     </div>
                   ))}

--- a/src/utils/postbox/postboxWrapper.ts
+++ b/src/utils/postbox/postboxWrapper.ts
@@ -695,6 +695,8 @@ export class DispatchForum implements IForum {
       await Promise.all(fetchableMetadata.map(async (r)=> {
         const fetchedURI = await fetch(r.uri);
         const parsed = await fetchedURI.json()
+        // TODO(andrew) handle the case where the fetched
+        // metadata does not have an image field
         r.uri = parsed?.image as string 
       }))
 

--- a/src/utils/postbox/postboxWrapper.ts
+++ b/src/utils/postbox/postboxWrapper.ts
@@ -738,6 +738,7 @@ export class DispatchForum implements IForum {
           if (result.error) {
             console.error(result.error);
           }
+          return false;
         }
       }) as DisplayableToken[];
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,19 @@
+import { DispatchClientError } from '../types/loading';
+import { dispatchClientError } from './loading';
+
+/**
+ * Attempt to parse a URL from a string. On success, return the
+ * URL object. On failure, return a DispatchClientError.
+ *
+ * TODO(andrew) make the Error type more generic in naming. This
+ * function's error result doesn't have anything to do with the
+ * Dispatch Client, so the fact that it returns thie error is
+ * misleading
+ */
+export function stringToURL(text: string): URL | DispatchClientError {
+  try {
+    return new URL(text);
+  } catch (e) {
+    return dispatchClientError(e);
+  }
+}


### PR DESCRIPTION
Fixes https://www.notion.so/usedispatch/Bug-When-owning-an-NFT-with-an-insecure-asset-the-entire-Gifting-UI-crashes-ba91aa94c1234aaf974a60489dd7dd64 and handles non-NFT metadata accounts