### PR TITLE
fix: don't call hook during SOL transfer

### DIFF
--- a/src/components/forums/topic/GiveAward.tsx
+++ b/src/components/forums/topic/GiveAward.tsx
@@ -57,6 +57,7 @@ export function GiveAward(props: GiveAwardProps) {
         posterId: post.poster,
         collectionId: collectionId,
         amount: selectedAmount,
+        connection: Forum.connection
       });
       setLoading(false);
       onSuccess(
@@ -236,11 +237,16 @@ interface TransferSOLProps {
   posterId: web3.PublicKey;
   collectionId: web3.PublicKey;
   amount: number;
+  connection: web3.Connection;
 }
 
 async function transferSOL(props: TransferSOLProps) {
-  const { posterId, amount, wallet } = props;
-  const { connection } = useForum();
+  const {
+    posterId,
+    amount,
+    wallet,
+    connection
+  } = props;
 
   let tx = new web3.Transaction().add(
     web3.SystemProgram.transfer({


### PR DESCRIPTION
Fixes an issue where gifting SOL was impossible due to an [erroneous hook call](https://github.com/usedispatch/dispatch-forum-npm-package/pull/83/files#diff-a37df89eb035f1e65fea439d37f7355e11c4ba896cbd52559111204004d1b44fL243) during the transfer function. Hooks should [only be called during render](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-from-react-functions).