### PR TITLE
fix: redirect to main forum after topic delete

### DIFF
--- a/src/components/forums/topic/TopicContent.tsx
+++ b/src/components/forums/topic/TopicContent.tsx
@@ -140,7 +140,9 @@ export function TopicContent(props: TopicContentProps) {
         okPath: forumPath,
       });
       if (tx) {
-        await forum.connection.confirmTransaction(tx).then(() => update());
+        await forum.connection
+          .confirmTransaction(tx)
+          .then(() => location.assign('..'));
       }
       setShowDeleteConfirmation(false);
       setDeletingTopic(false);

--- a/src/components/forums/topic/TopicContent.tsx
+++ b/src/components/forums/topic/TopicContent.tsx
@@ -140,6 +140,8 @@ export function TopicContent(props: TopicContentProps) {
         okPath: forumPath,
       });
       if (tx) {
+        // When the topic is confirmed deleted, redirect to the
+        // parent URL (the main forum)
         await forum.connection
           .confirmTransaction(tx)
           .then(() => location.assign('..'));


### PR DESCRIPTION
Currently, when deleting a topic, the topic disappears and the user is shown an error. This PR fixes this by redirecting back to the forum instead