### PR TITLE
Code Maintenance: Move manage tools

### DIFF
--- a/src/components/forums/forum/ForumContent.tsx
+++ b/src/components/forums/forum/ForumContent.tsx
@@ -11,10 +11,9 @@ import {
   PermissionsGate,
   PopUpModal,
   TransactionLink,
-  Spinner
+  Spinner,
 } from "../../common";
-import { EditForum } from "./EditForum";
-import { TopicList } from "..";
+import { TopicList, EditForum, ManageOwners } from "..";
 import { useRole } from "../../../contexts/DispatchProvider";
 
 import { DispatchForum } from "../../../utils/postbox/postboxWrapper";
@@ -26,6 +25,7 @@ import {
   restrictionListToString,
   pubkeysToRestriction,
 } from "../../../utils/restrictionListHelper";
+
 interface ForumContentProps {
   forumObject: DispatchForum;
   forumData: ForumData;
@@ -52,26 +52,14 @@ export function ForumContent(props: ForumContentProps) {
     forumObject
   );
 
-  const [currentOwners, setCurrentOwners] = useState<string[]>(() => {
-    if (isSuccess(forumData.owners)) {
-      return forumData.owners.map((pkey) => pkey.toBase58());
-    } else {
-      // TODO(andrew) show error here for missing owners
-      return [];
-    }
-  });
-
   const [showNewTopicModal, setShowNewTopicModal] = useState(false);
   const [creatingNewTopic, setCreatingNewTopic] = useState(false);
   const [newTopicInFlight, setNewTopicInFlight] = useState(false);
   const [keepGates, setKeepGates] = useState(true);
 
   const [showAddModerators, setShowAddModerators] = useState(false);
-  const [showAddOwners, setShowAddOwners] = useState(false);
   const [newModerator, setNewModerator] = useState<string>("");
-  const [newOwner, setNewOwner] = useState<string>("");
   const [addingNewModerator, setAddingNewModerator] = useState(false);
-  const [addingNewOwner, setAddingNewOwner] = useState(false);
   const [ungatedNewTopic, setUngatedNewTopic] = useState(false);
   const [showManageAccessToken, setShowManageAccessToken] = useState(false);
   const [removeAccessToken, setRemoveAccessToken] = useState<{
@@ -145,40 +133,6 @@ export function ForumContent(props: ForumContentProps) {
           type: MessageType.error,
           body: `The moderators could not be added`,
           collapsible: { header: "Error", content: error.message },
-        });
-      }
-    }
-  };
-
-  const addOwner = async () => {
-    setAddingNewOwner(true);
-    try {
-      const ownerId = newPublicKey(newOwner);
-      const tx = await forumObject.addOwner(ownerId, forumData.collectionId);
-      setCurrentOwners(currentOwners.concat(newOwner));
-      setNewOwner("");
-      setShowAddOwners(false);
-      setAddingNewOwner(false);
-      setModalInfo({
-        title: "Success!",
-        type: MessageType.success,
-        body: (
-          <div className="successBody">
-            <div>The owner was added</div>
-            <TransactionLink transaction={tx!} />
-          </div>
-        ),
-      });
-    } catch (error: any) {
-      setAddingNewOwner(false);
-      if (error.code !== 4001) {
-        setNewOwner("");
-        setShowAddOwners(false);
-        setModalInfo({
-          title: "Something went wrong!",
-          type: MessageType.error,
-          body: `The owners could not be added`,
-          collapsible: { header: "Error", content: JSON.stringify(error) },
         });
       }
     }
@@ -318,12 +272,10 @@ export function ForumContent(props: ForumContentProps) {
         setShowNewTopicModal(false);
 
         // re-load forum in background
-        await forumObject.connection
-          .confirmTransaction(tx)
-          .then(() => {
-            update();
-            setNewTopicInFlight(false);
-          });
+        await forumObject.connection.confirmTransaction(tx).then(() => {
+          update();
+          setNewTopicInFlight(false);
+        });
       } else {
         setCreatingNewTopic(false);
         setModalInfo({
@@ -685,45 +637,6 @@ export function ForumContent(props: ForumContentProps) {
               onClose={() => setShowAddModerators(false)}
             />
           )}
-          {_.isNil(modalInfo) && showAddOwners && (
-            <PopUpModal
-              id="add-owners"
-              visible
-              title={"Manage owners"}
-              body={
-                <div className="addModeratorsBody">
-                  <label className="addModeratorsLabel">Add new</label>
-                  <input
-                    placeholder="Add owners's wallet ID here"
-                    className="addModeratorsInput"
-                    maxLength={800}
-                    value={newOwner}
-                    onChange={(e) => setNewOwner(e.target.value)}
-                  />
-                  <label className="addModeratorsLabel">Current owners</label>
-                  <ul>
-                    {currentOwners.map((m) => {
-                      return (
-                        <li key={m} className="currentModerators">
-                          <div className="iconContainer">
-                            <Jdenticon value={m} alt="moderatorId" />
-                          </div>
-                          {m}
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </div>
-              }
-              loading={addingNewOwner}
-              okButton={
-                <button className="okButton" onClick={() => addOwner()}>
-                  Save
-                </button>
-              }
-              onClose={() => setShowAddOwners(false)}
-            />
-          )}
           <div className="forumContentBox">
             {forumHeader}
             <PermissionsGate scopes={[SCOPES.canEditForum]}>
@@ -732,14 +645,7 @@ export function ForumContent(props: ForumContentProps) {
                 <div className="lock">
                   <Lock />
                 </div>
-                <PermissionsGate scopes={[SCOPES.canAddOwner]}>
-                  <button
-                    className="moderatorTool owners"
-                    disabled={!permission.readAndWrite}
-                    onClick={() => setShowAddOwners(true)}>
-                    Manage owners
-                  </button>
-                </PermissionsGate>
+                <ManageOwners forumData={forumData} />
                 <PermissionsGate scopes={[SCOPES.canEditMods]}>
                   <button
                     className="moderatorTool"
@@ -762,9 +668,9 @@ export function ForumContent(props: ForumContentProps) {
           </div>
           {(() => {
             if (newTopicInFlight) {
-              return <Spinner />
+              return <Spinner />;
             } else if (!_.isNil(forumData.collectionId)) {
-              return <TopicList forumData={forumData} />
+              return <TopicList forumData={forumData} />;
             }
           })()}
         </>

--- a/src/components/forums/forum/ManageModerators.tsx
+++ b/src/components/forums/forum/ManageModerators.tsx
@@ -1,0 +1,229 @@
+import * as _ from "lodash";
+import { useState, ReactNode, useMemo } from "react";
+import Jdenticon from "react-jdenticon";
+
+import {
+  CollapsibleProps,
+  MessageType,
+  PermissionsGate,
+  PopUpModal,
+  TransactionLink,
+} from "../../common";
+import { Notification } from "..";
+import { useForum } from "../../../contexts/DispatchProvider";
+
+import { ForumData, useModerators } from "../../../utils/hooks";
+import { NOTIFICATION_BANNER_TIMEOUT } from "../../../utils/consts";
+import { isSuccess } from "../../../utils/loading";
+import { newPublicKey } from "../../../utils/postbox/validateNewPublicKey";
+import { SCOPES } from "../../../utils/permissions";
+
+interface ManageModeratorsProps {
+  forumData: ForumData;
+}
+
+export function ManageModerators(props: ManageModeratorsProps) {
+  const { forumData } = props;
+  const forumObject = useForum();
+  const { permission } = forumObject;
+
+  // here, moderators will always refer to the mods as fetched
+  // from the server, which is an immutable value and can only be
+  // changed by calling updateMods(). currentMods is the mutable
+  // value that can be edited client-side
+  const { moderators, update: updateMods } = useModerators(
+    forumData.collectionId,
+    forumObject
+  );
+
+  const [manageModerators, setManageModerators] = useState<{
+    show: boolean;
+    newModerator: string;
+    addingNewModerator: boolean;
+  }>({
+    show: false,
+    newModerator: "",
+    addingNewModerator: false,
+  });
+
+  const resetInitialValues = () => {
+    setManageModerators({
+      show: false,
+      newModerator: "",
+      addingNewModerator: false,
+    });
+  };
+
+  const [notificationContent, setNotificationContent] = useState<{
+    isHidden: boolean;
+    content?: string | ReactNode;
+    type?: MessageType;
+  }>({ isHidden: true });
+  const [modalInfo, setModalInfo] = useState<{
+    title: string | ReactNode;
+    type: MessageType;
+    body?: string | ReactNode;
+    collapsible?: CollapsibleProps;
+  } | null>(null);
+
+  // Begin mutating operations
+  const addModerator = async () => {
+    // In order to add moderators, they must have been fetched successfully at least once.
+    // This means that moderators must be a success type (indicating it was fetched successfully from server)
+    if (!isSuccess(moderators)) {
+      return;
+    }
+
+    setManageModerators({ ...manageModerators, addingNewModerator: true });
+    try {
+      const moderatorId = newPublicKey(manageModerators.newModerator);
+      const tx = await forumObject.addModerator(
+        moderatorId,
+        forumData.collectionId
+      );
+      resetInitialValues();
+      setNotificationContent({
+        isHidden: false,
+        content: (
+          <>
+            The moderator was added.
+            <TransactionLink transaction={tx!} />
+          </>
+        ),
+        type: MessageType.success,
+      });
+      setTimeout(
+        () => setNotificationContent({ isHidden: true }),
+        NOTIFICATION_BANNER_TIMEOUT
+      );
+
+      forumObject.connection.confirmTransaction(tx!).then(() => updateMods());
+    } catch (error: any) {
+      setManageModerators({ ...manageModerators, addingNewModerator: true });
+      if (error.error?.code !== 4001) {
+        resetInitialValues();
+        setModalInfo({
+          title: "Something went wrong!",
+          type: MessageType.error,
+          body: `The moderator could not be added`,
+          collapsible: { header: "Error", content: error.error.message },
+        });
+      }
+    }
+  };
+
+  const moderatorsFetched = isSuccess(moderators);
+
+  const BodyContent = () => {
+    // If the moderators were successfully fetched and currentMods was set...
+    if (moderatorsFetched) {
+      const moderatorList = moderators.map((pubkey) => {
+        const m = pubkey.toBase58();
+        return (
+          <li key={m} className="currentModerators">
+            <>
+              <div className="iconContainer">
+                <Jdenticon value={m} alt="moderatorId" />
+              </div>
+              {m}
+            </>
+          </li>
+        );
+      });
+
+      return (
+        <>
+          <label className="manageModeratorsLabel">Current moderators</label>
+          <ul>{moderatorList}</ul>
+          <label className="manageModeratorsLabel">Add new</label>
+          <input
+            placeholder="Add moderator's wallet ID here"
+            className="manageModeratorsInput"
+            maxLength={800}
+            value={manageModerators.newModerator}
+            onChange={(e) =>
+              setManageModerators({
+                ...manageModerators,
+                newModerator: e.target.value,
+              })
+            }
+          />
+        </>
+      );
+    } else {
+      return (
+        <div className="emptyList">
+          Click to load the list of current moderators
+        </div>
+      );
+    }
+  };
+
+  return (
+    <div className="dsp- ">
+      <div className="manageModeratorsContainer">
+        <Notification
+          hidden={notificationContent.isHidden}
+          content={notificationContent?.content}
+          type={notificationContent?.type}
+          onClose={() => setNotificationContent({ isHidden: true })}
+        />
+        {_.isNil(modalInfo) && manageModerators.show && (
+          <PopUpModal
+            id="add-moderators"
+            visible
+            title={"Manage moderators"}
+            body={
+              <div className="manageModeratorsBody">
+                <BodyContent />
+              </div>
+            }
+            loading={manageModerators.addingNewModerator}
+            okButton={
+              moderatorsFetched ? (
+                <button
+                  className="okButton"
+                  disabled={!manageModerators.newModerator.length}
+                  onClick={() => addModerator()}>
+                  Save
+                </button>
+              ) : (
+                <button
+                  className="okButton fetchModerators"
+                  onClick={updateMods}>
+                  Fetch moderators
+                </button>
+              )
+            }
+            onClose={() => resetInitialValues()}
+          />
+        )}
+        {!_.isNil(modalInfo) && (
+          <PopUpModal
+            id="manage-moderators-info"
+            visible
+            title={modalInfo.title}
+            messageType={modalInfo.type}
+            body={modalInfo.body}
+            collapsible={modalInfo.collapsible}
+            okButton={
+              <a className="okButton" onClick={() => setModalInfo(null)}>
+                OK
+              </a>
+            }
+          />
+        )}
+        <PermissionsGate scopes={[SCOPES.canEditMods]}>
+          <button
+            className="manageModeratorsButton"
+            disabled={!permission.readAndWrite}
+            onClick={() =>
+              setManageModerators({ ...manageModerators, show: true })
+            }>
+            Manage moderators
+          </button>
+        </PermissionsGate>
+      </div>
+    </div>
+  );
+}

--- a/src/components/forums/forum/ManageOwners.tsx
+++ b/src/components/forums/forum/ManageOwners.tsx
@@ -1,0 +1,213 @@
+import * as _ from "lodash";
+import { useState, ReactNode, useMemo } from "react";
+import Jdenticon from "react-jdenticon";
+
+import {
+  CollapsibleProps,
+  MessageType,
+  PermissionsGate,
+  PopUpModal,
+  TransactionLink,
+} from "../../common";
+import { Notification } from "..";
+import { useForum } from "../../../contexts/DispatchProvider";
+
+import { ForumData } from "../../../utils/hooks";
+import { NOTIFICATION_BANNER_TIMEOUT } from "../../../utils/consts";
+import { isSuccess } from "../../../utils/loading";
+import { newPublicKey } from "../../../utils/postbox/validateNewPublicKey";
+import { SCOPES } from "../../../utils/permissions";
+
+interface ManageOwnersProps {
+  forumData: ForumData;
+}
+
+export function ManageOwners(props: ManageOwnersProps) {
+  const { forumData } = props;
+  const forumObject = useForum();
+  const { permission } = forumObject;
+
+  const [manageOwners, setManageOwners] = useState<{
+    show: boolean;
+    newOwner: string;
+    currentOwners: string[];
+    addingNewOwner: boolean;
+  }>(() => {
+    let owners: string[] = [];
+    if (isSuccess(forumData.owners)) {
+      owners = forumData.owners.map((pkey) => pkey.toBase58());
+    } else {
+      // TODO(andrew) show error here for missing owners
+    }
+
+    return {
+      show: false,
+      newOwner: "",
+      currentOwners: owners,
+      addingNewOwner: false,
+    };
+  });
+
+  const resetInitialValues = () => {
+    let owners: string[] = [];
+    if (isSuccess(forumData.owners)) {
+      owners = forumData.owners.map((pkey) => pkey.toBase58());
+    } else {
+      // TODO(andrew) show error here for missing owners
+    }
+
+    setManageOwners({
+      show: false,
+      newOwner: "",
+      currentOwners: owners,
+      addingNewOwner: false,
+    });
+  };
+
+  const [notificationContent, setNotificationContent] = useState<{
+    isHidden: boolean;
+    content?: string | ReactNode;
+    type?: MessageType;
+  }>({ isHidden: true });
+  const [modalInfo, setModalInfo] = useState<{
+    title: string | ReactNode;
+    type: MessageType;
+    body?: string | ReactNode;
+    collapsible?: CollapsibleProps;
+  } | null>(null);
+
+  const isOwner = useMemo(async () => {
+    return forumObject.isOwner(forumData.collectionId);
+  }, [forumObject]);
+
+  const addOwner = async () => {
+    setManageOwners({ ...manageOwners, addingNewOwner: true });
+    try {
+      const ownerId = newPublicKey(manageOwners.newOwner);
+      const tx = await forumObject.addOwner(ownerId, forumData.collectionId);
+
+      setManageOwners({
+        show: false,
+        currentOwners: manageOwners.currentOwners.concat(manageOwners.newOwner),
+        newOwner: "",
+        addingNewOwner: false,
+      });
+      setNotificationContent({
+        isHidden: false,
+        content: (
+          <>
+            The owner was added.
+            <TransactionLink transaction={tx!} />
+          </>
+        ),
+        type: MessageType.success,
+      });
+      setTimeout(
+        () => setNotificationContent({ isHidden: true }),
+        NOTIFICATION_BANNER_TIMEOUT
+      );
+    } catch (error: any) {
+      setManageOwners({ ...manageOwners, addingNewOwner: false });
+      if (error.error?.code !== 4001) {
+        setManageOwners({
+          ...manageOwners,
+          newOwner: "",
+          show: false,
+        });
+        setModalInfo({
+          title: "Something went wrong!",
+          type: MessageType.error,
+          body: `The owner could not be added`,
+          collapsible: { header: "Error", content: error },
+        });
+      }
+    }
+  };
+
+  if (!isOwner) {
+    return null;
+  }
+
+  return (
+    <div className="dsp- ">
+      <div className="manageOwnersContainer">
+        <Notification
+          hidden={notificationContent.isHidden}
+          content={notificationContent?.content}
+          type={notificationContent?.type}
+          onClose={() => setNotificationContent({ isHidden: true })}
+        />
+        {_.isNil(modalInfo) && manageOwners.show && (
+          <PopUpModal
+            id="add-owners"
+            visible
+            title={"Manage owners"}
+            body={
+              <div className="manageOwnersBody">
+                <label className="manageOwnersLabel">Add new</label>
+                <input
+                  placeholder="Add owners's wallet ID here"
+                  className="manageOwnersInput"
+                  maxLength={800}
+                  value={manageOwners.newOwner}
+                  onChange={(e) =>
+                    setManageOwners({
+                      ...manageOwners,
+                      newOwner: e.target.value,
+                    })
+                  }
+                />
+                <label className="manageOwnersLabel">Current owners</label>
+                <ul>
+                  {manageOwners.currentOwners.map((m) => {
+                    return (
+                      <li key={m} className="currentOwners">
+                        <div className="iconContainer">
+                          <Jdenticon value={m} alt="ownerId" />
+                        </div>
+                        {m}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            }
+            loading={manageOwners.addingNewOwner}
+            okButton={
+              <button
+                className="okButton"
+                disabled={!manageOwners.newOwner.length}
+                onClick={() => addOwner()}>
+                Save
+              </button>
+            }
+            onClose={() => resetInitialValues()}
+          />
+        )}
+        {!_.isNil(modalInfo) && (
+          <PopUpModal
+            id="manage-owners-info"
+            visible
+            title={modalInfo.title}
+            messageType={modalInfo.type}
+            body={modalInfo.body}
+            collapsible={modalInfo.collapsible}
+            okButton={
+              <a className="okButton" onClick={() => setModalInfo(null)}>
+                OK
+              </a>
+            }
+          />
+        )}
+        <PermissionsGate scopes={[SCOPES.canAddOwner]}>
+          <button
+            className="manageOwnersButton"
+            disabled={!permission.readAndWrite}
+            onClick={() => setManageOwners({ ...manageOwners, show: true })}>
+            Manage owners
+          </button>
+        </PermissionsGate>
+      </div>
+    </div>
+  );
+}

--- a/src/components/forums/index.tsx
+++ b/src/components/forums/index.tsx
@@ -5,6 +5,7 @@ export * from "./PoweredByDispatch";
 export * from "./forum/CreateForum";
 export * from "./forum/EditForum";
 export * from "./forum/ForumContent";
+export * from "./forum/ManageOwners";
 export * from "./forum/TopicList";
 
 export * from "./topic/CreatePost";

--- a/src/components/forums/index.tsx
+++ b/src/components/forums/index.tsx
@@ -5,6 +5,7 @@ export * from "./PoweredByDispatch";
 export * from "./forum/CreateForum";
 export * from "./forum/EditForum";
 export * from "./forum/ForumContent";
+export * from "./forum/ManageModerators";
 export * from "./forum/ManageOwners";
 export * from "./forum/TopicList";
 

--- a/src/style.css
+++ b/src/style.css
@@ -19,6 +19,7 @@
 @import "./styles/CreateForum.css";
 @import "./styles/EditForum.css";
 @import "./styles/ForumContent.css";
+@import "./styles/ManageOwners.css";
 @import "./styles/TopicList.css";
 
 /* Topic */

--- a/src/style.css
+++ b/src/style.css
@@ -20,6 +20,7 @@
 @import "./styles/EditForum.css";
 @import "./styles/ForumContent.css";
 @import "./styles/ManageOwners.css";
+@import "./styles/ManageModerator.css";
 @import "./styles/TopicList.css";
 
 /* Topic */

--- a/src/styles/ForumContent.css
+++ b/src/styles/ForumContent.css
@@ -202,10 +202,6 @@
     background: transparent;
     color: #3f1d96;
 
-    &.owners {
-      margin-left: 0;
-    }
-
     &:hover {
       opacity: 0.85;
     }

--- a/src/styles/ManageModerator.css
+++ b/src/styles/ManageModerator.css
@@ -1,0 +1,149 @@
+@layer components {
+  .manageModeratorsContainer {
+    display: flex;
+
+    .manageModeratorsButton {
+      display: flex;
+      align-items: center;
+      margin-left: 24px;
+
+      background: transparent;
+      color: #4a279c;
+
+      &:hover {
+        opacity: 0.85;
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        opacity: 0.65;
+      }
+
+      svg {
+        height: 12px;
+        width: 12px;
+        margin-right: 6px;
+      }
+    }
+
+    .manageModeratorsBody {
+      display: flex;
+      flex-direction: column;
+      justify-content: justify-end;
+      margin-bottom: 12px;
+      width: 100%;
+
+      font-family: Manrope, sans-serif;
+      font-size: 14px;
+
+      ul {
+        padding-left: 0;
+        max-height: 260px;
+        overflow-y: overlay;
+      }
+
+      .manageModeratorsInput {
+        width: 100%;
+        height: 32px;
+        font-size: 14px;
+        padding: 16px;
+        margin-top: 4px;
+        margin-bottom: 24px;
+
+        border-color: #d1d5db;
+        border-width: 1px;
+        border-radius: 6px;
+
+        &:focus {
+          outline: 2px solid transparent;
+          outline-offset: 2px;
+        }
+      }
+
+      .emptyList {
+        align-items: flex-start;
+        color: #86878e;
+      }
+    }
+
+    .manageModeratorsLabel {
+      margin-bottom: 8px;
+      font-size: 16px;
+      font-weight: 500;
+    }
+
+    .currentModerators {
+      display: flex;
+      align-items: center;
+      margin: 0 0 8px 0;
+      font-size: 14px;
+      font-weight: 400;
+      color: #414149;
+    }
+
+    .iconContainer {
+      heigh: 28px;
+      width: 28px;
+      margin-right: 8px;
+    }
+
+    .okButton {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      white-space: nowrap;
+
+      height: 48px;
+      padding: 0 16px;
+      border-radius: 6px;
+
+      background: #3f1d96;
+      color: white;
+      font-size: 14px;
+      text-align: center;
+      text-transform: capitalize;
+      font-weight: 600;
+
+      &:hover {
+        opacity: 0.85;
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+      }
+
+      &.fetchModerators {
+        margin: 0 auto;
+      }
+    }
+
+    .cancelButton {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      height: 48px;
+      padding: 0 16px;
+      border-radius: 6px;
+      border-width: 1px;
+      border-color: #3f1d96;
+
+      background: white;
+      color: #3f1d96;
+      font-size: 14px;
+      font-weight: 600;
+      text-align: center;
+      text-transform: capitalize;
+
+      &:hover {
+        opacity: 0.85;
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+      }
+    }
+  }
+}

--- a/src/styles/ManageOwners.css
+++ b/src/styles/ManageOwners.css
@@ -1,0 +1,145 @@
+@layer components {
+  .manageOwnersContainer {
+    display: flex;
+
+    .successBody {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .manageOwnersButton {
+      display: flex;
+      align-items: center;
+      margin-left: 24px;
+
+      background: transparent;
+      color: #4a279c;
+
+      &:hover {
+        opacity: 0.85;
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        opacity: 0.65;
+      }
+
+      svg {
+        height: 12px;
+        width: 12px;
+        margin-right: 6px;
+      }
+    }
+
+    .manageOwnersBody {
+      display: flex;
+      flex-direction: column;
+      justify-content: justify-end;
+      margin-bottom: 12px;
+      width: 100%;
+
+      font-family: Manrope, sans-serif;
+      font-size: 14px;
+
+      ul {
+        padding-left: 0;
+        max-height: 260px;
+        overflow-y: overlay;
+      }
+
+      .manageOwnersInput {
+        width: 100%;
+        height: 32px;
+        font-size: 14px;
+        padding: 16px;
+        margin-top: 4px;
+        margin-bottom: 24px;
+
+        border-color: #d1d5db;
+        border-width: 1px;
+        border-radius: 6px;
+
+        &:focus {
+          outline: 2px solid transparent;
+          outline-offset: 2px;
+        }
+      }
+    }
+
+    .manageOwnersLabel {
+      margin-bottom: 8px;
+      font-size: 16px;
+      font-weight: 500;
+    }
+
+    .currentOwners {
+      display: flex;
+      align-items: center;
+      margin: 0 0 8px 0;
+      font-size: 14px;
+      font-weight: 400;
+      color: #414149;
+    }
+
+    .iconContainer {
+      heigh: 28px;
+      width: 28px;
+      margin-right: 8px;
+    }
+
+    .okButton {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      white-space: nowrap;
+
+      height: 48px;
+      padding: 0 16px;
+      border-radius: 6px;
+
+      background: #3f1d96;
+      color: white;
+      font-size: 14px;
+      text-align: center;
+      text-transform: capitalize;
+      font-weight: 600;
+
+      &:hover {
+        opacity: 0.85;
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+      }
+    }
+
+    .cancelButton {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      height: 48px;
+      padding: 0 16px;
+      border-radius: 6px;
+      border-width: 1px;
+      border-color: #3f1d96;
+
+      background: white;
+      color: #3f1d96;
+      font-size: 14px;
+      font-weight: 600;
+      text-align: center;
+      text-transform: capitalize;
+
+      &:hover {
+        opacity: 0.85;
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
Move the logic and style of "manage owners" and "manage moderators" from ForumContent (which grew too big and had too many states) to new separate components: ManageOwners and ManageModerators respectively. This way the code is easier to understand and modify when necessary. There are no changes in style or logic
