### PR TITLE
[Paused] [Oct 3]: Track Gifting Posts

### DIFF
--- a/src/components/forums/topic/GiveAward.tsx
+++ b/src/components/forums/topic/GiveAward.tsx
@@ -1,7 +1,8 @@
 import * as _ from "lodash";
 import { useState, ReactNode } from "react";
 import * as web3 from "@solana/web3.js";
-import { ForumPost, WalletAdapterInterface } from "@usedispatch/client";
+import {NATIVE_MINT, getAssociatedTokenAddress} from "@solana/spl-token";
+import { ForumPost, WalletAdapterInterface, Mailbox } from "@usedispatch/client";
 
 import {
   CollapsibleProps,
@@ -52,13 +53,34 @@ export function GiveAward(props: GiveAwardProps) {
     setLoading(true);
 
     try {
-      const tx = await transferSOL({
-        wallet: Forum.wallet,
-        posterId: post.poster,
-        collectionId: collectionId,
-        amount: selectedAmount,
-        connection: Forum.connection,
-      });
+      const mailbox = new Mailbox(Forum.connection, Forum.wallet);
+      const ata = await 
+      getAssociatedTokenAddress(NATIVE_MINT, Forum.wallet.publicKey!);
+
+      if (ata) {
+        const tx = await mailbox.sendMessage(
+          "You've received a Dispatch SOL Award!",
+          `You've received an award from ${Forum.wallet.publicKey!.toBase58()}!`,
+          post.poster,
+          {
+            incentive: {
+              mint: NATIVE_MINT,
+              amount: selectedAmount,
+              payerAccount: ata,
+            }
+          }
+        )
+      } else {
+        const sendTx = new web3.Transaction();
+        
+      }
+      // const tx = await transferSOL({
+      //   wallet: Forum.wallet,
+      //   posterId: post.poster,
+      //   collectionId: collectionId,
+      //   amount: selectedAmount,
+      //   connection: Forum.connection,
+      // });
       setLoading(false);
       onSuccess(
         <>
@@ -82,6 +104,7 @@ export function GiveAward(props: GiveAwardProps) {
         selectedNFT?.mint!,
         Forum.wallet.sendTransaction
       );
+
 
       setLoading(false);
       onSuccess(

--- a/src/components/forums/topic/PostContent.tsx
+++ b/src/components/forums/topic/PostContent.tsx
@@ -1,9 +1,9 @@
 import * as _ from "lodash";
 import { PublicKey } from "@solana/web3.js";
 import Markdown from "markdown-to-jsx";
-import { ReactNode, useMemo, useRef, useState } from "react";
+import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import Jdenticon from "react-jdenticon";
-import { ForumPost } from "@usedispatch/client";
+import { ForumPost, Mailbox, MessageAccount } from "@usedispatch/client";
 
 import { Gift, Trash, Reply, Info } from "../../../assets";
 import {
@@ -12,6 +12,7 @@ import {
   PermissionsGate,
   PopUpModal,
   Spinner,
+  Tooltip,
   TransactionLink,
 } from "./../../common";
 import { Votes, Notification } from "../../../components/forums";
@@ -67,7 +68,6 @@ export function PostContent(props: PostContentProps) {
   } = props;
 
   const permission = forum.permission;
-
   const userIsMod = useUserIsMod(
     forumData.collectionId,
     forum,
@@ -79,7 +79,8 @@ export function PostContent(props: PostContentProps) {
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const [postToDelete, setPostToDelete] = useState(props.post);
   const [deleting, setDeleting] = useState(false);
-
+  const [awardGiven, setAwardGiven] = useState(false);
+  const [awards, setAwards] = useState<MessageAccount[]>();
   const [showReplyBox, setShowReplyBox] = useState(false);
   const [reply, setReply] = useState("");
   const [sendingReply, setSendingReply] = useState(false);
@@ -116,6 +117,21 @@ export function PostContent(props: PostContentProps) {
   }, [forumData, post]);
 
   const replyAreaRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+
+    const fetchAwards = async() => {
+        if (isForumPost(post)) {
+        const mailbox = new Mailbox(forum.connection, forum.wallet);
+        const awards = await mailbox.fetchMessagesByAddress(post.address);
+        if (awards.length > 0) {
+          setAwardGiven(true);
+          setAwards(awards);
+        }
+    }
+    };
+    fetchAwards();
+  }, []);
 
   const updateVotes = (upVoted: boolean) => {
     if (isForumPost(post)) {
@@ -371,6 +387,7 @@ export function PostContent(props: PostContentProps) {
                       moderators={participatingModerators}
                     />
                   </div>
+                  {awardGiven && awards && <Tooltip content={<div>🏆</div>} message={awards[0].data.body}/>}
                 </div>
                 <div className="postedAt">
                   {(() => {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3940879/190471497-a419dd0b-f820-4087-8448-3615e3ca0b57.png)


a sample implementation of tracking votes using messages for SOL gifting, still need to add NFT gift tracking

dependent on https://github.com/usedispatch/msg/pull/88