### PR TITLE
Add text-overflow: ellipsis

### DIFF
--- a/src/styles/TopicView.css
+++ b/src/styles/TopicView.css
@@ -14,6 +14,10 @@
       color: #4a279c;
       text-decoration: none;
 
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+
       &:hover {
         opacity: 0.65;
       }
@@ -32,6 +36,9 @@
 
     .current {
       overflow-wrap: anywhere;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
     }
   }
 

--- a/src/styles/customizations/DegenApeAcademy.css
+++ b/src/styles/customizations/DegenApeAcademy.css
@@ -277,13 +277,23 @@
       color: white;
     }
 
-    .breadcrumbContainer,
-    .parent {
-      color: #999999;
-      font-weight: 500;
+    .breadcrumbContainer {
+      .parent {
+        color: #999999;
+        font-weight: 500;
 
-      svg path {
-        stroke: #999999;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+
+        svg path {
+          stroke: #999999;
+        }
+      }
+      .current {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
       }
     }
 

--- a/src/styles/customizations/Metaplex.css
+++ b/src/styles/customizations/Metaplex.css
@@ -279,13 +279,23 @@
       color: white;
     }
 
-    .breadcrumbContainer,
-    .parent {
-      color: #999999;
-      font-weight: 500;
+    .breadcrumbContainer {
+      .parent {
+        color: #999999;
+        font-weight: 500;
 
-      svg path {
-        stroke: #999999;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+
+        svg path {
+          stroke: #999999;
+        }
+      }
+      .current {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
       }
     }
 

--- a/src/styles/customizations/Solana.css
+++ b/src/styles/customizations/Solana.css
@@ -279,13 +279,23 @@
       color: white;
     }
 
-    .breadcrumbContainer,
-    .parent {
-      color: #999999;
-      font-weight: 500;
+    .breadcrumbContainer {
+      .parent {
+        color: #999999;
+        font-weight: 500;
 
-      svg path {
-        stroke: #999999;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+
+        svg path {
+          stroke: #999999;
+        }
+      }
+      .current {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
       }
     }
 

--- a/src/styles/themes/Dark.css
+++ b/src/styles/themes/Dark.css
@@ -341,13 +341,23 @@
       color: white;
     }
 
-    .breadcrumbContainer,
-    .parent {
-      color: #999999;
-      font-weight: 500;
+    .breadcrumbContainer {
+      .parent {
+        color: #999999;
+        font-weight: 500;
 
-      svg path {
-        stroke: #999999;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+
+        svg path {
+          stroke: #999999;
+        }
+      }
+      .current {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
       }
     }
 


### PR DESCRIPTION
### Ticket
[Make sure headers in mobile look up to spec regarding design](https://www.notion.so/usedispatch/Make-sure-headers-in-mobile-look-up-to-spec-regarding-design-b31e4561baa944c6aa8739d224a8532a)

### Description
This pr adds an ellipsis when the text overflows in the breadcrumb

### Screenshots
Before:

![localhost_3000_forum_83V8YXXd7AURNWRAtqeoGsnAbQk16zr68TAWZw5bSzfF_topic_1_cluster=devnet (3)](https://user-images.githubusercontent.com/57630050/197551332-7b2923cf-b86e-4c11-8d2e-40836d39c9f5.png)


After:
![localhost_3000_forum_83V8YXXd7AURNWRAtqeoGsnAbQk16zr68TAWZw5bSzfF_topic_1_cluster=devnet (2)](https://user-images.githubusercontent.com/57630050/197551386-6a94822c-3409-43fd-a701-a95a7f903cfb.png)
