### PR TITLE
Fix Moderator Check for Gifting

### DIFF
--- a/src/components/forums/topic/TopicContent.tsx
+++ b/src/components/forums/topic/TopicContent.tsx
@@ -32,7 +32,6 @@ import {
   ForumData,
   CreatedPost,
   EditedPost,
-  useUserIsMod,
   useForumIdentity,
   ForumIdentity,
   isEditedPost,
@@ -182,12 +181,7 @@ export function TopicContent(props: TopicContentProps): JSX.Element {
     type: MessageType;
   }>();
 
-  const userIsMod = useUserIsMod(
-    forumData.collectionId,
-    forum,
-    forum.wallet.publicKey ?? new PublicKey('11111111111111111111111111111111'),
-  ) ?? false;
-
+  const userIsMod = userRoles.includes(UserRoleType.Moderator);
   const forumIdentity = useForumIdentity(forumData.collectionId);
 
   const [showAddAccessToken, setShowAddAccessToken] = useState(false);


### PR DESCRIPTION
Current behavior:

1. Visit a degeniverse topic
2. Connect a wallet with moderator token
3. Send Token and other Moderator Functionality is not enabled on posts and replies

EXPECTED
Step 3 should have moderator functions on UI

FIX:

Use global role permissions instead of one-time check 